### PR TITLE
fix: add check for the nil prevV

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -229,7 +229,7 @@ func addPathsToVertexList(paths Paths64, polytype PathType, isOpen bool, minimaL
 				prevV = currV
 			}
 		}
-		if prevV.prev == nil {
+		if prevV == nil || prevV.prev == nil {
 			continue
 		}
 		if !isOpen && prevV.pt == v0.pt {


### PR DESCRIPTION
Hi, in my inner tests I have encountered panic when prevV was nil. I think it is due the input path was empty.

I think that little check will help and not damage overall functionality.